### PR TITLE
upgraded the version of @kinde/js-utils pakcage from 0.6.0 to 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ],
     "dependencies": {
         "@babel/runtime": "^7.19.4",
-        "@kinde/js-utils": "^0.6.0",
+        "@kinde/js-utils": "^0.7.3",
         "crypto-js": "3.3.0",
         "jwt-decode": "^3.1.2",
         "react-native-inappbrowser-reborn": ">= 3.7",


### PR DESCRIPTION
# Explain your changes

When I installed the latest version `2.0.1` of `@kinde-oss/react-native-sdk-0-7x` in React Native 0.76.5 and tried to log in, I encountered the issue `TypeError: Cannot assign to property 'search' which has only a getter`. This issue was caused by `@kinde/js-utils`. When I upgraded its version from `0.6.0` to `0.7.3`, the issue has been resolved.

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
