### PR TITLE
refactor: move native dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
         "@kinde/js-utils": "^0.18.3",
         "crypto-js": "^4.2.0",
         "jwt-decode": "^3.1.2",
-        "react-native-get-random-values": "^1.11.0",
-        "react-native-app-auth": "^8.0.0",
-        "react-native-keychain": "^8.0.0",
         "url-parse": "^1.5.10"
     },
     "devDependencies": {
@@ -86,6 +83,9 @@
         "prettier": "^2.7.1",
         "react": "18.1.0",
         "react-native": "0.70.8",
+        "react-native-app-auth": "^8.0.0",
+        "react-native-get-random-values": "^1.11.0",
+        "react-native-keychain": "^8.0.0",
         "react-test-renderer": "18.1.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^29.1.0",


### PR DESCRIPTION
# Explain your changes

This PR moves the following native dependencies into `devDependencies` in the `package.json` file. 

This allows consuming apps to determine their version of the peer dependencies without locking them into the version we previously have locked in `dependencies`. 

## Verifying Fix:

When a consuming app updates its `react-native-keychain` version to `10.0.0`:

### Previously:
The `8.2.0` version from the SDK is installed alongside the `10.0.0`

```shell
> npm ls react-native-keychain

KindeSDKRN@0.0.1 <project-root>
├─┬ @kinde-oss/react-native-sdk-0-7x@2.2.0
│ └── react-native-keychain@8.2.0 
└── react-native-keychain@10.0.0
```

### Now: 
Only the `10.0.0` is installed:

```shell
> npm ls react-native-keychain

KindeSDKRN@0.0.1 <project-root>
├─┬ @kinde-oss/react-native-sdk-0-7x@2.2.0
│ └── react-native-keychain@10.0.0 deduped
└── react-native-keychain@10.0.0  
```

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
