### PR TITLE
chore: update react-native to 0.73.0 and react-native-keychain to 10.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ You can also use the React Native 0.7x starter kit [here](https://github.com/ki
 | Platform | Minimum Version |
 | -------- | --------------- |
 | iOS      | 12.0+           |
-| Android  | API 21+         |
+| Android  | API 23+         |
 
-> **Note:** iOS 12.0+ is required due to the dependency on `react-native-app-auth`, which uses [AppAuth-iOS 2.0.0](https://github.com/openid/AppAuth-iOS/releases/tag/2.0.0). If your app targets iOS versions below 12.0, you will need to update your deployment target.
+> [!NOTE]
+> - **iOS:** 12.0+ is required due to the dependency on `react-native-app-auth`, which uses [AppAuth-iOS 2.0.0](https://github.com/openid/AppAuth-iOS/releases/tag/2.0.0). If your app targets iOS versions below 12.0, you will need to update your deployment target.
+> - **Android:** API 23+ is required due to the dependency on `react-native-keychain`, which has a minimum SDK version of [23](https://github.com/oblador/react-native-keychain/blob/v10.0.0/android/gradle.properties#L14).
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "@babel/register": "^7.0.0",
         "@types/crypto-js": "^4.2.2",
         "@types/node": "^18.11.7",
-        "@types/react-native": "^0.70.6",
+        "@types/react": "^18.2.0",
         "@types/react-native-get-random-values": "^1.8.2",
         "@types/url-parse": "^1.4.8",
         "babel-core": "^7.0.0-bridge.0",
@@ -81,21 +81,21 @@
         "lint-staged": "^13.0.3",
         "metro-react-native-babel-preset": "^0.73.3",
         "prettier": "^2.7.1",
-        "react": "18.1.0",
-        "react-native": "0.70.8",
+        "react": "18.2.0",
+        "react-native": "0.73.0",
         "react-native-app-auth": "^8.0.0",
         "react-native-get-random-values": "^1.11.0",
-        "react-native-keychain": "^8.0.0",
-        "react-test-renderer": "18.1.0",
+        "react-native-keychain": "^10.0.0",
+        "react-test-renderer": "18.2.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^29.1.0",
         "typescript": "^4.9.5"
     },
     "peerDependencies": {
-        "react-native": ">= 0.70",
+        "react-native": ">= 0.73",
         "react-native-get-random-values": ">= 1.10",
         "react-native-app-auth": ">= 8.0",
-        "react-native-keychain": ">= 8.0"
+        "react-native-keychain": ">= 10.0"
     },
     "files": [
         "dist"


### PR DESCRIPTION
# Explain your changes

This PR updates the `react-native-keychain` version to `10.0.0`. `10.0.0` removes the deprecated `FacebookConceal` library (which contained native libs that don’t meet the newer Android 16 KB page size requirement). 

## Additional changes: 

- `react-native` was upgraded to `0.73.0` as `react-native-keychain` version `10.0.0` contains AGP 8  features, which were adopted in React Native in version `0.73.0`.
  
- `react` and related libraries like `react-test-renderer` were upgraded to `18.2.0` as required by `react-native` version `0.73.0`.

- `@types/react-native` was removed as React Native from version `0.7.1` includes its own types natively. `@types/react` was added for the React types. 

## Testing

This new version has been tested and validated on Android and iOS. 

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
