### PR TITLE
refactor: remove redirect URI check for invitation code deep links

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -309,14 +309,14 @@ describe('KindeSDK', () => {
             loginSpy.mockRestore();
         });
 
-        test('does not call login when the url is not a Kinde redirect url', async () => {
+        test('does not call login when the url has no invitation code', async () => {
             const loginSpy = jest.spyOn(KindeSDK.prototype, 'login');
 
             const testUrls = [
                 'test.com',
                 'test.com/kinde_callback',
                 'myapp://test.com/kinde_callback',
-                'myapp://test.com/kinde_callback?invitation_code=random_code'
+                'myapp://myhost.kinde.com/kinde_callback'
             ];
 
             for (const url of testUrls) {
@@ -327,23 +327,11 @@ describe('KindeSDK', () => {
             loginSpy.mockRestore();
         });
 
-        test('does not call login when the url is a Kinde redirect url but has no invitation code parameter', async () => {
+        test('calls login with "create" prompt and invitationCode when the url has an invitation code parameter', async () => {
             const loginSpy = jest.spyOn(KindeSDK.prototype, 'login');
 
             globalClient.handleDeepLink(
-                'myapp://myhost.kinde.com/kinde_callback'
-            );
-
-            expect(loginSpy).not.toHaveBeenCalled();
-
-            loginSpy.mockRestore();
-        });
-
-        test('calls login with "create" prompt and invitationCode when the url is a Kinde redirect url with an invitation code parameter', async () => {
-            const loginSpy = jest.spyOn(KindeSDK.prototype, 'login');
-
-            globalClient.handleDeepLink(
-                'myapp://myhost.kinde.com/kinde_callback?invitation_code=random_code'
+                'myapp://test.com/anything?invitation_code=random_code'
             );
 
             expect(loginSpy).toHaveBeenCalledWith({

--- a/src/SDK/KindeSDK.ts
+++ b/src/SDK/KindeSDK.ts
@@ -113,25 +113,16 @@ class KindeSDK extends runtime.BaseAPI {
         if (!url) return;
 
         const URLParsed = new Url(url, true);
-        const redirectUrlParsed = new Url(this.redirectUri, true);
-
-        const isKindeRedirectUrl =
-            URLParsed.protocol === redirectUrlParsed.protocol &&
-            URLParsed.host === redirectUrlParsed.host &&
-            URLParsed.pathname === redirectUrlParsed.pathname;
-
-        if (!isKindeRedirectUrl) return;
-
         const { invitation_code: invitationCode } = URLParsed.query;
 
-        if (invitationCode) {
-            this.login({
-                prompt: PromptTypes.create,
-                invitationCode: invitationCode
-            }).catch((error) => {
-                console.warn('Failed to process invitation deep link:', error);
-            });
-        }
+        if (!invitationCode) return;
+
+        this.login({
+            prompt: PromptTypes.create,
+            invitationCode: invitationCode
+        }).catch((error) => {
+            console.warn('Failed to process invitation deep link:', error);
+        });
     }
 
     /**


### PR DESCRIPTION
# Explain your changes

In the current implementation, the SDK only allows invitation codes from login redirect URIs to be processed. 

This PR removes the check, keeping the SDK's behaviour the same as the other SDKs.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
