### PR TITLE
Feat/token write result token persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,13 @@ You can also use the React Native 0.7x starter kit [here](https://github.com/ki
 ## Requirements
 
 | Platform | Minimum Version |
-| -------- | --------------- |
+| ----------| -----------------|
 | iOS      | 12.0+           |
 | Android  | API 23+         |
 
 > [!NOTE]
->
-> -   **iOS:** 12.0+ is required due to the dependency on `react-native-app-auth`, which uses [AppAuth-iOS 2.0.0](https://github.com/openid/AppAuth-iOS/releases/tag/2.0.0). If your app targets iOS versions below 12.0, you will need to update your deployment target.
-> -   **Android:** API 23+ is required due to the dependency on `react-native-keychain`, which has a minimum SDK version of [23](https://github.com/oblador/react-native-keychain/blob/v10.0.0/android/gradle.properties#L14).
+> - **iOS:** 12.0+ is required due to the dependency on `react-native-app-auth`, which uses [AppAuth-iOS 2.0.0](https://github.com/openid/AppAuth-iOS/releases/tag/2.0.0). If your app targets iOS versions below 12.0, you will need to update your deployment target.
+> - **Android:** API 23+ is required due to the dependency on `react-native-keychain`, which has a minimum SDK version of [23](https://github.com/oblador/react-native-keychain/blob/v10.0.0/android/gradle.properties#L14).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ You can also use the React Native 0.7x starter kit [here](https://github.com/ki
 | Android  | API 23+         |
 
 > [!NOTE]
-> - **iOS:** 12.0+ is required due to the dependency on `react-native-app-auth`, which uses [AppAuth-iOS 2.0.0](https://github.com/openid/AppAuth-iOS/releases/tag/2.0.0). If your app targets iOS versions below 12.0, you will need to update your deployment target.
-> - **Android:** API 23+ is required due to the dependency on `react-native-keychain`, which has a minimum SDK version of [23](https://github.com/oblador/react-native-keychain/blob/v10.0.0/android/gradle.properties#L14).
+>
+> -   **iOS:** 12.0+ is required due to the dependency on `react-native-app-auth`, which uses [AppAuth-iOS 2.0.0](https://github.com/openid/AppAuth-iOS/releases/tag/2.0.0). If your app targets iOS versions below 12.0, you will need to update your deployment target.
+> -   **Android:** API 23+ is required due to the dependency on `react-native-keychain`, which has a minimum SDK version of [23](https://github.com/oblador/react-native-keychain/blob/v10.0.0/android/gradle.properties#L14).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can also use the React Native 0.7x starter kit [here](https://github.com/ki
 ## Requirements
 
 | Platform | Minimum Version |
-| ----------| -----------------|
+| -------- | --------------- |
 | iOS      | 12.0+           |
 | Android  | API 23+         |
 

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -172,6 +172,24 @@ const dataDecoded = {
 
 jest.mock('jwt-decode', () => jest.fn().mockReturnValue());
 
+const createKeychainMock = (initialPassword = null) => {
+    const storage = { password: initialPassword };
+    return {
+        storage,
+        getItem: jest.fn(async () =>
+            storage.password
+                ? { username: 'kinde', password: storage.password }
+                : false
+        ),
+        setItem: jest.fn(async (value) => {
+            storage.password =
+                typeof value === 'string' ? value : JSON.stringify(value);
+            return true;
+        })
+    };
+};
+
+let keychainMock = createKeychainMock();
 let globalClient;
 describe('KindeSDK', () => {
     beforeEach(() => {
@@ -184,11 +202,9 @@ describe('KindeSDK', () => {
             configuration.logoutRedirectUri
         );
 
-        RNStorage.prototype.getItem = jest
-            .fn()
-            .mockReturnValue({ password: null });
-
-        RNStorage.prototype.setItem = jest.fn();
+        keychainMock = createKeychainMock();
+        RNStorage.prototype.getItem = keychainMock.getItem;
+        RNStorage.prototype.setItem = keychainMock.setItem;
 
         global.fetch = jest.fn(() =>
             Promise.resolve({
@@ -577,16 +593,17 @@ describe('KindeSDK', () => {
         });
 
         test('[RNStorage] Check authenticated use refresh_token', async () => {
-            RNStorage.prototype.getItem = jest.fn().mockReturnValue({
-                password: JSON.stringify({
-                    ...fakeTokenResponse,
-                    access_token: '',
-                    expires_in: 0
-                })
+            keychainMock.storage.password = JSON.stringify({
+                ...fakeTokenResponse,
+                access_token: '',
+                expires_in: 0
             });
 
             const authenticated = await globalClient.isAuthenticated;
             expect(authenticated).toEqual(true);
+            expect(keychainMock.storage.password).toBe(
+                JSON.stringify(fakeTokenResponse)
+            );
         });
 
         test('[RNStorage] Get Token instance when user is authenticated', async () => {
@@ -755,6 +772,32 @@ describe('KindeSDK', () => {
         });
     });
 
+    describe('token persistence', () => {
+        test('[RNStorage] setToken throws when secure storage write is rejected', async () => {
+            RNStorage.prototype.setItem = jest.fn().mockResolvedValue(false);
+
+            await expect(Storage.setToken(fakeTokenResponse)).rejects.toMatchObject(
+                {
+                    name: 'TokenPersistenceError',
+                    message: 'Secure storage rejected the token write'
+                }
+            );
+        });
+
+        test('[RNStorage] setToken throws when access token is missing after read-back', async () => {
+            RNStorage.prototype.setItem = jest.fn().mockResolvedValue(true);
+            RNStorage.prototype.getItem = jest.fn().mockResolvedValue(false);
+
+            await expect(Storage.setToken(fakeTokenResponse)).rejects.toMatchObject(
+                {
+                    name: 'TokenPersistenceError',
+                    message:
+                        'Access token was not found in secure storage after persist'
+                }
+            );
+        });
+    });
+
     describe('forceTokenRefresh', () => {
         test(`[RNStorage] Throws an error if no refresh token found in storage`, async () => {
             RNStorage.prototype.getItem = jest.fn().mockReturnValue({
@@ -766,17 +809,10 @@ describe('KindeSDK', () => {
         });
 
         test('[RNStorage] Stores newly fetched tokens in storage', async () => {
-            let storage = {
-                username: 'kinde',
-                password: JSON.stringify(fakeTokenResponse)
-            };
-            RNStorage.prototype.getItem = jest.fn(() => storage);
-            RNStorage.prototype.setItem = jest.fn((value: unknown) => {
-                storage.password = JSON.stringify(value);
-            });
+            keychainMock.storage.password = JSON.stringify(fakeTokenResponse);
 
             const formData = new FormData();
-            const { refresh_token } = JSON.parse(storage.password);
+            const { refresh_token } = JSON.parse(keychainMock.storage.password);
             formData.append('client_id', configuration.clientId);
             formData.append('grant_type', 'refresh_token');
             formData.append('refresh_token', refresh_token);
@@ -796,7 +832,17 @@ describe('KindeSDK', () => {
             await globalClient.forceTokenRefresh();
             expect(global.fetch).toHaveBeenCalled();
             expect(global.fetch.mock.calls[0][1].body).toEqual(formData);
-            expect(storage.password).toBe(JSON.stringify(newTokensResponse));
+            expect(keychainMock.storage.password).toBe(
+                JSON.stringify(newTokensResponse)
+            );
+        });
+
+        test('[RNStorage] returns null when token persist fails after refresh', async () => {
+            keychainMock.storage.password = JSON.stringify(fakeTokenResponse);
+            RNStorage.prototype.setItem = jest.fn().mockResolvedValue(false);
+
+            const response = await globalClient.forceTokenRefresh();
+            expect(response).toBe(null);
         });
 
         test(`[RNStorage] returns "null" in the event network call rejects`, async () => {

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -776,25 +776,25 @@ describe('KindeSDK', () => {
         test('[RNStorage] setToken throws when secure storage write is rejected', async () => {
             RNStorage.prototype.setItem = jest.fn().mockResolvedValue(false);
 
-            await expect(Storage.setToken(fakeTokenResponse)).rejects.toMatchObject(
-                {
-                    name: 'TokenPersistenceError',
-                    message: 'Secure storage rejected the token write'
-                }
-            );
+            await expect(
+                Storage.setToken(fakeTokenResponse)
+            ).rejects.toMatchObject({
+                name: 'TokenPersistenceError',
+                message: 'Secure storage rejected the token write'
+            });
         });
 
         test('[RNStorage] setToken throws when access token is missing after read-back', async () => {
             RNStorage.prototype.setItem = jest.fn().mockResolvedValue(true);
             RNStorage.prototype.getItem = jest.fn().mockResolvedValue(false);
 
-            await expect(Storage.setToken(fakeTokenResponse)).rejects.toMatchObject(
-                {
-                    name: 'TokenPersistenceError',
-                    message:
-                        'Access token was not found in secure storage after persist'
-                }
-            );
+            await expect(
+                Storage.setToken(fakeTokenResponse)
+            ).rejects.toMatchObject({
+                name: 'TokenPersistenceError',
+                message:
+                    'Access token was not found in secure storage after persist'
+            });
         });
     });
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":rebaseStalePrs"]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended", ":rebaseStalePrs"]
 }

--- a/src/SDK/KindeSDK.ts
+++ b/src/SDK/KindeSDK.ts
@@ -448,7 +448,12 @@ class KindeSDK extends runtime.BaseAPI {
                 return;
             }
 
-            await Storage.setToken(dataResponse);
+            try {
+                await Storage.setToken(dataResponse);
+            } catch (error) {
+                reject(error);
+                return;
+            }
             resolve(dataResponse);
         });
     }
@@ -718,7 +723,11 @@ class KindeSDK extends runtime.BaseAPI {
 
             try {
                 const token = await this.useRefreshToken(refreshToken);
-                return (token?.expires_in || 0) > 0;
+                if ((token?.expires_in || 0) <= 0) {
+                    return false;
+                }
+                const accessToken = await Storage.getAccessToken();
+                return Boolean(accessToken);
             } catch (_) {
                 return false;
             }

--- a/src/SDK/Storage/index.ts
+++ b/src/SDK/Storage/index.ts
@@ -1,4 +1,5 @@
 import jwtDecode from 'jwt-decode';
+import { TokenPersistenceError } from '../../common/exceptions/token-persistence.exception';
 import {
     AccessTokenDecoded,
     IdTokenDecoded,
@@ -35,9 +36,35 @@ class Storage extends BaseStore {
         }
     }
 
-    async setToken(token: string) {
+    async setToken(token: string | TokenResponse): Promise<void> {
         const storage = await this.getStorage();
-        return storage.setItem(token);
+        const expected =
+            typeof token === 'string'
+                ? (JSON.parse(token) as TokenResponse)
+                : token;
+
+        const written = await storage.setItem(token);
+        if (!written) {
+            throw new TokenPersistenceError(
+                'Secure storage rejected the token write'
+            );
+        }
+
+        const stored = await this.getToken();
+        if (!stored?.access_token) {
+            throw new TokenPersistenceError(
+                'Access token was not found in secure storage after persist'
+            );
+        }
+
+        if (
+            expected.access_token &&
+            stored.access_token !== expected.access_token
+        ) {
+            throw new TokenPersistenceError(
+                'Persisted access token does not match the expected value'
+            );
+        }
     }
 
     async getTokenType(type: TokenType) {

--- a/src/SDK/Storage/index.ts
+++ b/src/SDK/Storage/index.ts
@@ -38,12 +38,10 @@ class Storage extends BaseStore {
 
     async setToken(token: string | TokenResponse): Promise<void> {
         const storage = await this.getStorage();
-        const expected =
-            typeof token === 'string'
-                ? (JSON.parse(token) as TokenResponse)
-                : token;
+        const serializedToken = this.convertString(token);
+        const expected = JSON.parse(serializedToken) as TokenResponse;
 
-        const written = await storage.setItem(token);
+        const written = await storage.setItem(serializedToken);
         if (!written) {
             throw new TokenPersistenceError(
                 'Secure storage rejected the token write'
@@ -142,7 +140,7 @@ class Storage extends BaseStore {
     }
 }
 
-const sessionStorage = (globalThis.sessionStorage =
-    globalThis.sessionStorage ?? new Storage()) as Storage;
+const sessionStorage = (globalThis.__kindeSdkStorage =
+    globalThis.__kindeSdkStorage ?? new Storage());
 
 export default sessionStorage;

--- a/src/common/exceptions/token-persistence.exception.ts
+++ b/src/common/exceptions/token-persistence.exception.ts
@@ -1,0 +1,8 @@
+export class TokenPersistenceError extends Error {
+    public name: string;
+
+    constructor(message = 'Failed to persist authentication tokens to secure storage') {
+        super(message);
+        this.name = 'TokenPersistenceError';
+    }
+}

--- a/src/common/exceptions/token-persistence.exception.ts
+++ b/src/common/exceptions/token-persistence.exception.ts
@@ -6,5 +6,6 @@ export class TokenPersistenceError extends Error {
     ) {
         super(message);
         this.name = 'TokenPersistenceError';
+        Object.setPrototypeOf(this, TokenPersistenceError.prototype);
     }
 }

--- a/src/common/exceptions/token-persistence.exception.ts
+++ b/src/common/exceptions/token-persistence.exception.ts
@@ -1,7 +1,9 @@
 export class TokenPersistenceError extends Error {
     public name: string;
 
-    constructor(message = 'Failed to persist authentication tokens to secure storage') {
+    constructor(
+        message = 'Failed to persist authentication tokens to secure storage'
+    ) {
         super(message);
         this.name = 'TokenPersistenceError';
     }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,7 +1,8 @@
 import Storage from '../SDK/Storage';
 
 declare global {
-    var sessionStorage: typeof Storage;
+    /** Kinde SDK token store singleton (not the browser SessionStorage API). */
+    var __kindeSdkStorage: Storage;
     /** React Native development mode flag */
     var __DEV__: boolean;
 }


### PR DESCRIPTION
# Explain your changes

1. Write failures
  - setToken checks write result + read-back; fetchToken rejects on failure; TokenPersistenceError added

2. isAuthenticated vs keychain
- Partial Touch — refresh path now requires Storage.getAccessToken() after refresh (same task, not a separate pass)

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
