### PR TITLE
Feat/verify token persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ You can also use the React Native 0.7x starter kit [here](https://github.com/ki
 | Android  | API 23+         |
 
 > [!NOTE]
-> - **iOS:** 12.0+ is required due to the dependency on `react-native-app-auth`, which uses [AppAuth-iOS 2.0.0](https://github.com/openid/AppAuth-iOS/releases/tag/2.0.0). If your app targets iOS versions below 12.0, you will need to update your deployment target.
-> - **Android:** API 23+ is required due to the dependency on `react-native-keychain`, which has a minimum SDK version of [23](https://github.com/oblador/react-native-keychain/blob/v10.0.0/android/gradle.properties#L14).
+>
+> -   **iOS:** 12.0+ is required due to the dependency on `react-native-app-auth`, which uses [AppAuth-iOS 2.0.0](https://github.com/openid/AppAuth-iOS/releases/tag/2.0.0). If your app targets iOS versions below 12.0, you will need to update your deployment target.
+> -   **Android:** API 23+ is required due to the dependency on `react-native-keychain`, which has a minimum SDK version of [23](https://github.com/oblador/react-native-keychain/blob/v10.0.0/android/gradle.properties#L14).
 
 ## Development
 

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -131,6 +131,9 @@ jest.mock(process.cwd() + '/src/SDK/Utils', () => ({
     ).additionalParametersToLoginMethodParams,
     isLikelyUserCancelled: jest.requireActual(process.cwd() + '/src/SDK/Utils')
         .isLikelyUserCancelled,
+    extractAccessTokenExpiry: jest.requireActual(
+        process.cwd() + '/src/SDK/Utils'
+    ).extractAccessTokenExpiry,
     checkNotNull: jest.fn((reference, name) => {
         if (reference === null || reference === undefined) {
             throw new Error(`${name} cannot be empty`);

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -1,6 +1,10 @@
 // @ts-nocheck
 
+const React = require('react');
+const TestRenderer = require('react-test-renderer');
+const { act } = TestRenderer;
 const { KindeSDK } = require(process.cwd() + '/src/index');
+const { useKindeProvider } = require(process.cwd() + '/src/SDK/KindeProvider');
 import jwtDecode from 'jwt-decode';
 import Url from 'url-parse';
 import RNStorage from '../src/SDK/Storage/RNStorage';
@@ -606,6 +610,17 @@ describe('KindeSDK', () => {
             );
         });
 
+        test('[RNStorage] Check not authenticated when JWT valid but access token missing from storage', async () => {
+            keychainMock.storage.password = JSON.stringify({
+                ...fakeTokenResponse,
+                access_token: '',
+                refresh_token: ''
+            });
+
+            const authenticated = await globalClient.isAuthenticated;
+            expect(authenticated).toEqual(false);
+        });
+
         test('[RNStorage] Get Token instance when user is authenticated', async () => {
             RNStorage.prototype.getItem = jest.fn().mockReturnValue({
                 password: JSON.stringify({
@@ -796,6 +811,25 @@ describe('KindeSDK', () => {
                     'Access token was not found in secure storage after persist'
             });
         });
+
+        test('[RNStorage] setToken throws when persisted access token does not match expected', async () => {
+            RNStorage.prototype.setItem = jest.fn().mockResolvedValue(true);
+            RNStorage.prototype.getItem = jest.fn().mockResolvedValue({
+                username: 'kinde',
+                password: JSON.stringify({
+                    ...fakeTokenResponse,
+                    access_token: 'different_access_token'
+                })
+            });
+
+            await expect(
+                Storage.setToken(fakeTokenResponse)
+            ).rejects.toMatchObject({
+                name: 'TokenPersistenceError',
+                message:
+                    'Persisted access token does not match the expected value'
+            });
+        });
     });
 
     describe('forceTokenRefresh', () => {
@@ -858,6 +892,129 @@ describe('KindeSDK', () => {
             const response = await globalClient.forceTokenRefresh();
             expect(response).toBe(null);
             expect(global.fetch).toHaveBeenCalled();
+        });
+    });
+
+    describe('KindeProvider', () => {
+        const providerConfiguration = {
+            issuerUrl: configuration.issuer,
+            clientId: configuration.clientId,
+            redirectUri: configuration.redirectUri,
+            logoutRedirectUri: configuration.logoutRedirectUri
+        };
+
+        const renderProvider = () => {
+            const providerRef = { current: null };
+            const TestComponent = () => {
+                providerRef.current = useKindeProvider(providerConfiguration);
+                return null;
+            };
+
+            act(() => {
+                TestRenderer.create(React.createElement(TestComponent));
+            });
+
+            return providerRef;
+        };
+
+        let setRefreshTimerSpy;
+        let clearAllSpy;
+
+        beforeEach(() => {
+            jwtDecode.mockReset();
+            jwtDecode.mockReturnValue(dataDecoded);
+            setRefreshTimerSpy = jest
+                .spyOn(require('@kinde/js-utils'), 'setRefreshTimer')
+                .mockImplementation(() => {});
+            clearAllSpy = jest
+                .spyOn(Storage, 'clearAll')
+                .mockResolvedValue(undefined);
+        });
+
+        afterEach(() => {
+            setRefreshTimerSpy.mockRestore();
+            clearAllSpy.mockRestore();
+            jwtDecode.mockReset();
+        });
+
+        test('verifyToken sets authenticated when a valid access token is persisted', async () => {
+            keychainMock.storage.password = JSON.stringify(fakeTokenResponse);
+            jwtDecode.mockReturnValue(dataDecoded);
+
+            const providerRef = renderProvider();
+
+            await act(async () => {
+                await providerRef.current.verifyToken();
+            });
+
+            expect(providerRef.current.isAuthenticated).toBe(true);
+            expect(setRefreshTimerSpy).toHaveBeenCalled();
+            expect(clearAllSpy).not.toHaveBeenCalled();
+        });
+
+        test('verifyToken sets authenticated after a successful token refresh', async () => {
+            keychainMock.storage.password = JSON.stringify(fakeTokenResponse);
+            jwtDecode.mockReturnValue({
+                ...dataDecoded,
+                exp: Math.floor(Date.now() / 1000) - 100
+            });
+
+            const providerRef = renderProvider();
+
+            await act(async () => {
+                await providerRef.current.verifyToken();
+            });
+
+            expect(providerRef.current.isAuthenticated).toBe(true);
+            expect(clearAllSpy).not.toHaveBeenCalled();
+        });
+
+        test('verifyToken clears session when token refresh fails', async () => {
+            keychainMock.storage.password = JSON.stringify(fakeTokenResponse);
+            jwtDecode.mockReturnValue({
+                ...dataDecoded,
+                exp: Math.floor(Date.now() / 1000) - 100
+            });
+            RNStorage.prototype.setItem = jest.fn().mockResolvedValue(false);
+
+            const providerRef = renderProvider();
+
+            await act(async () => {
+                await providerRef.current.verifyToken();
+            });
+
+            expect(providerRef.current.isAuthenticated).toBe(false);
+            expect(clearAllSpy).toHaveBeenCalled();
+        });
+
+        test('verifyToken clears session when refresh succeeds but access token is not persisted', async () => {
+            jwtDecode.mockReturnValue({
+                ...dataDecoded,
+                exp: Math.floor(Date.now() / 1000) - 100
+            });
+
+            const getAccessTokenSpy = jest.spyOn(Storage, 'getAccessToken');
+            getAccessTokenSpy
+                .mockResolvedValueOnce('this_is_access_token')
+                .mockResolvedValueOnce(null);
+
+            const KindeSDKModule = require(process.cwd() +
+                '/src/SDK/KindeSDK').default;
+            const forceTokenRefreshSpy = jest
+                .spyOn(KindeSDKModule.prototype, 'forceTokenRefresh')
+                .mockResolvedValue(fakeTokenResponse);
+
+            const providerRef = renderProvider();
+
+            await act(async () => {
+                await providerRef.current.verifyToken();
+            });
+
+            expect(providerRef.current.isAuthenticated).toBe(false);
+            expect(clearAllSpy).toHaveBeenCalled();
+
+            getAccessTokenSpy.mockRestore();
+            forceTokenRefreshSpy.mockRestore();
         });
     });
 

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -966,6 +966,7 @@ describe('KindeSDK', () => {
             });
 
             expect(providerRef.current.isAuthenticated).toBe(true);
+            expect(setRefreshTimerSpy).toHaveBeenCalled();
             expect(clearAllSpy).not.toHaveBeenCalled();
         });
 

--- a/src/SDK/KindeProvider.ts
+++ b/src/SDK/KindeProvider.ts
@@ -39,6 +39,10 @@ export const useKindeProvider = ({
                     await handleLogout();
                 } else {
                     setIsAuthenticated(true);
+                    setRefreshTimer(
+                        await Storage.getExpiredAt(),
+                        authSdk.forceTokenRefresh
+                    );
                 }
             }
         } catch (error) {

--- a/src/SDK/KindeProvider.ts
+++ b/src/SDK/KindeProvider.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { KindeSDK, Storage } from '..';
+import { extractAccessTokenExpiry, KindeSDK, Storage } from '..';
 import { setRefreshTimer } from '@kinde/js-utils';
 
 export interface KindeProviderProps {
@@ -24,26 +24,33 @@ export const useKindeProvider = ({
 
     const verifyToken = async () => {
         try {
-            const tokenExpiry = await Storage.getExpiredAt();
+            const accessToken = await Storage.getAccessToken();
+            const tokenExpiry = extractAccessTokenExpiry(accessToken);
             const currentTime = Math.floor(Date.now() / 1000);
             const remainingTime = tokenExpiry - currentTime;
 
-            const accessToken = await Storage.getAccessToken();
             if (accessToken && remainingTime > 10) {
                 setIsAuthenticated(true);
                 setRefreshTimer(tokenExpiry, authSdk.forceTokenRefresh);
             } else {
                 const refreshSuccess = await authSdk.forceTokenRefresh();
-                const persistedAccessToken = await Storage.getAccessToken();
-                if (!refreshSuccess || !persistedAccessToken) {
+
+                if (!refreshSuccess) {
                     await handleLogout();
-                } else {
-                    setIsAuthenticated(true);
-                    setRefreshTimer(
-                        await Storage.getExpiredAt(),
-                        authSdk.forceTokenRefresh
-                    );
+                    return;
                 }
+                const persistedAccessToken = await Storage.getAccessToken();
+                if (!persistedAccessToken) {
+                    await handleLogout();
+                    return;
+                }
+                const persistentAccessTokenExpiry =
+                    extractAccessTokenExpiry(persistedAccessToken);
+                setIsAuthenticated(true);
+                setRefreshTimer(
+                    persistentAccessTokenExpiry,
+                    authSdk.forceTokenRefresh
+                );
             }
         } catch (error) {
             console.error('Error verifying token:', error);

--- a/src/SDK/KindeProvider.ts
+++ b/src/SDK/KindeProvider.ts
@@ -24,17 +24,18 @@ export const useKindeProvider = ({
 
     const verifyToken = async () => {
         try {
-            const savedToken = await Storage.getToken();
             const tokenExpiry = await Storage.getExpiredAt();
             const currentTime = Math.floor(Date.now() / 1000);
             const remainingTime = tokenExpiry - currentTime;
 
-            if (savedToken && remainingTime > 10) {
+            const accessToken = await Storage.getAccessToken();
+            if (accessToken && remainingTime > 10) {
                 setIsAuthenticated(true);
                 setRefreshTimer(tokenExpiry, authSdk.forceTokenRefresh);
             } else {
                 const refreshSuccess = await authSdk.forceTokenRefresh();
-                if (!refreshSuccess) {
+                const persistedAccessToken = await Storage.getAccessToken();
+                if (!refreshSuccess || !persistedAccessToken) {
                     await handleLogout();
                 } else {
                     setIsAuthenticated(true);

--- a/src/SDK/KindeSDK.ts
+++ b/src/SDK/KindeSDK.ts
@@ -135,6 +135,18 @@ class KindeSDK extends runtime.BaseAPI {
     }
 
     /**
+     * True when a non-expired access token is present in secure storage.
+     */
+    private async hasValidPersistedAccessToken(): Promise<boolean> {
+        const accessToken = await Storage.getAccessToken();
+        if (!accessToken) {
+            return false;
+        }
+        const timeExpired = await Storage.getExpiredAt();
+        return timeExpired * 1000 > Date.now();
+    }
+
+    /**
      * The function takes an object as an argument, and if the object is empty, it will use the default
      * object
      * @param {AdditionalParameters} additionalParameters - LoginAdditionalParameters = {}
@@ -416,7 +428,9 @@ class KindeSDK extends runtime.BaseAPI {
             const response = await this.useRefreshToken(
                 currentToken.refresh_token
             );
-            await Storage.setToken(response as unknown as string);
+            if (!(await Storage.hasAccessToken())) {
+                return null;
+            }
             return response;
         } catch (error) {
             console.error('Failed to refresh token:', error);
@@ -706,11 +720,7 @@ class KindeSDK extends runtime.BaseAPI {
      */
     get isAuthenticated() {
         return (async () => {
-            const timeExpired = await Storage.getExpiredAt();
-            const now = new Date().getTime();
-
-            const isAuthenticated = timeExpired * 1000 > now;
-            if (isAuthenticated) {
+            if (await this.hasValidPersistedAccessToken()) {
                 return true;
             }
 
@@ -722,12 +732,11 @@ class KindeSDK extends runtime.BaseAPI {
             }
 
             try {
-                const token = await this.useRefreshToken(refreshToken);
-                if ((token?.expires_in || 0) <= 0) {
+                const refreshed = await this.useRefreshToken(refreshToken);
+                if ((refreshed?.expires_in || 0) <= 0) {
                     return false;
                 }
-                const accessToken = await Storage.getAccessToken();
-                return Boolean(accessToken);
+                return Storage.hasAccessToken();
             } catch (_) {
                 return false;
             }

--- a/src/SDK/KindeSDK.ts
+++ b/src/SDK/KindeSDK.ts
@@ -16,7 +16,8 @@ import Storage from './Storage';
 import {
     checkAdditionalParameters,
     checkNotNull,
-    convertObject2FormData
+    convertObject2FormData,
+    extractAccessTokenExpiry
 } from './Utils';
 import * as runtime from '../ApiClient';
 import { FLAG_TYPE } from './constants';
@@ -142,7 +143,7 @@ class KindeSDK extends runtime.BaseAPI {
         if (!accessToken) {
             return false;
         }
-        const timeExpired = await Storage.getExpiredAt();
+        const timeExpired = extractAccessTokenExpiry(accessToken);
         return timeExpired * 1000 > Date.now();
     }
 

--- a/src/SDK/Storage/index.ts
+++ b/src/SDK/Storage/index.ts
@@ -65,6 +65,10 @@ class Storage extends BaseStore {
         }
     }
 
+    async hasAccessToken(): Promise<boolean> {
+        return Boolean(await this.getAccessToken());
+    }
+
     async getTokenType(type: TokenType) {
         const token = await this.getToken();
         const newType =

--- a/src/SDK/Utils.ts
+++ b/src/SDK/Utils.ts
@@ -2,10 +2,11 @@ import CryptoJS from 'crypto-js';
 import { InvalidTypeException } from '../common/exceptions/invalid-type.exception';
 import { PropertyRequiredException } from '../common/exceptions/property-required.exception';
 import { UnexpectedException } from '../common/exceptions/unexpected.exception';
-import { AdditionalParameters } from '../types/KindeSDK';
+import { AccessTokenDecoded, AdditionalParameters } from '../types/KindeSDK';
 import { AdditionalParametersAllow } from './constants';
 import { LoginMethodParams } from '@kinde/js-utils';
 import 'react-native-get-random-values';
+import jwtDecode from 'jwt-decode';
 
 /**
  * It takes a string or a WordArray and returns a string
@@ -214,4 +215,20 @@ export const isLikelyUserCancelled = (error: unknown): boolean => {
         // iOS AppAuth error code -3 = OIDErrorCodeUserCanceledAuthorizationFlow
         /org\.openid\.appauth\.general error -3\b/.test(lower)
     );
+};
+
+/**
+ * Extracts the expiry time from a given access token.
+ * @param {string | null} accessToken - The access token to decode.
+ * @returns {number} The expiry time in seconds.
+ */
+export const extractAccessTokenExpiry = (
+    accessToken?: string | null
+): number => {
+    if (!accessToken) return 0;
+    try {
+        return jwtDecode<AccessTokenDecoded>(accessToken)?.['exp'] || 0;
+    } catch {
+        return 0;
+    }
 };


### PR DESCRIPTION
# Explain your changes

Step 2: Verify Token Persistence

Token persistence
setToken throws when persisted access token does not match expected - mocks a successful write but a read-back with a different access_token, asserting the third TokenPersistenceError path.
KindeProvider (verifyToken)
sets authenticated when a valid access token is persisted - valid token + expiry → isAuthenticated: true, setRefreshTimer called.
sets authenticated after a successful token refresh - expired token → refresh → authenticated.
clears session when token refresh fails - setItem returns false → logout via clearAll.
clears session when refresh succeeds but access token is not persisted - mocks forceTokenRefresh success with a missing post-refresh access token → logout.

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
